### PR TITLE
Add missing workshop host

### DIFF
--- a/src/workshops/020-helen-leigh.md
+++ b/src/workshops/020-helen-leigh.md
@@ -3,9 +3,10 @@ title: "Interfacing Hardware with Soft Things"
 start: 2025-5-31 2:00 PM
 end: 2025-5-31 4:00 PM
 location: Room 1
-presenter: Helen Leigh
+presenter: "Helen Leigh, Anu Reddy"
 presenters:
 - name: Helen Leigh
+- name: Anu Reddy
 ---
 
 Description coming soon!


### PR DESCRIPTION
As per the schedule spreadsheet, the "Interfacing Hardware with Soft Things" workshop has two organizers 🙂